### PR TITLE
Better error recovery on bad config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -34,19 +34,27 @@ export function getConfigFields() {
 	]
 
 	for (let i = 0; i <= 27; i++) {
+		const pinId = `use_gpio_${i}`
 		configuration_fields_arr.push(
 			{
 				type: 'static-text',
-				id: `GPIO_${i}_number`,
+				id: `space_${i}`,
 				width: 12,
+				label: `------------`,
+				value: ''
+			},
+			{
+				type: 'static-text',
+				id: `GPIO_${i}_number`,
+				width: 3,
 				label: `GPIO pin ${i}`,
 				value: `Configure GPIO pin number ${i}`,
 			},
 			{
 				type: 'checkbox',
-				width: 12,
+				width: 3,
 				label: `Use GPIO pin ${i}`,
-				id: `use_gpio_${i}`,
+				id: pinId,
 				default: false,
 			},
 			{
@@ -55,6 +63,10 @@ export function getConfigFields() {
 				label: 'Set as IN/OUT',
 				id: `gpio_in_out_${i}`,
 				default: 'out',
+				isVisibleData: { pinId: pinId },
+				isVisible: (opt, data) => {
+					return !!opt[data.pinId]
+				},
 				choices: [
 					{ id: 'out', label: 'OUTPUT' },
 					{ id: 'in', label: 'INPUT' },
@@ -66,6 +78,10 @@ export function getConfigFields() {
 				label: 'Trigger type',
 				id: `gpio_trigger_type_${i}`,
 				default: 'none',
+				isVisibleData: { pinId: pinId },
+				isVisible: (opt, data) => {
+					return !!opt[data.pinId]
+				},
 				choices: [
 					{ id: 'none', label: 'NONE' },
 					{ id: 'rising', label: 'RISING' },
@@ -79,6 +95,10 @@ export function getConfigFields() {
 				label: 'Enable debouncing',
 				id: `gpio_enable_debounce_${i}`,
 				default: false,
+				isVisibleData: { pinId: pinId },
+				isVisible: (opt, data) => {
+					return !!opt[data.pinId]
+				},
 			},
 			{
 				type: 'number',
@@ -88,14 +108,23 @@ export function getConfigFields() {
 				default: 10,
 				min: 0,
 				max: 60000,
+				isVisibleData: { pinId: pinId },
+				isVisible: (opt, data) => {
+					return !!opt[data.pinId]
+				},
 			},
 			{
 				type: 'checkbox',
-				width: 12,
+				width: 4,
 				label: 'Invert values on this pin',
 				id: `gpio_invert_values_${i}`,
 				default: false,
-			}
+				isVisibleData: { pinId: pinId },
+				isVisible: (opt, data) => {
+					return !!opt[data.pinId]
+				},
+			},
+
 		)
 	}
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -448,7 +448,13 @@ class GpioInstance extends InstanceBase {
 
 		for (const pinNumber of this.active_output_pins) {
 			console.log(`Pin_num: ${pinNumber} OUTPUT`)
-			this.active_output_pin_objects.set(pinNumber, new Gpio(pinNumber, 'out'))
+			try {
+				this.active_output_pin_objects.set(pinNumber, new Gpio(pinNumber, 'out'))
+			}
+			catch (err) {
+				this.log('error', `GPIO Output pin ${pinNumber} is inaccessible`)
+				this.updateStatus(InstanceStatus.ConnectionFailure, `Pin ${pinNumber} is inaccessible\n` + err.toString())
+			}
 		}
 
 		for (const [pinNumber, config] of this.active_input_pins.entries()) {
@@ -464,12 +470,19 @@ class GpioInstance extends InstanceBase {
 			console.log(`Debounce_time: ${debounce_time}`)
 			console.log(`Invert_values: ${invert_values}`)
 
-			const gpioHandle = new Gpio(pinNumber, 'in', trigger_type, {
-				debounceTimeout: debounce_enable ? debounce_time : undefined,
-				activeLow: invert_values,
-			})
+			try {
+				const gpioHandle = new Gpio(pinNumber, 'in', trigger_type, {
+					debounceTimeout: debounce_enable ? debounce_time : undefined,
+					activeLow: invert_values,
+				})
 
-			this.active_input_pin_objects.set(pinNumber, gpioHandle)
+				this.active_input_pin_objects.set(pinNumber, gpioHandle)
+			}
+
+			catch (err) {
+				this.log('error', `GPIO Input pin ${pinNumber} is inaccessible`)
+				this.updateStatus(InstanceStatus.ConnectionFailure, `Pin ${pinNumber} is inaccessible\n` + err.toString())
+			}
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raspberry-gpio",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "lib/main.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
A reserved pin can be 'configured'. 
This would crash the module after saving the config while preventing the config tab from activating.
Checks for this are now made to prevent lockup and display any errors.
