### PR TITLE
Acquire pin offset base for newer OS kernels

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,7 @@
 /**
  * @returns {import("@companion-module/base").SomeCompanionConfigField[]}
  */
-export function getConfigFields() {
+export function getConfigFields(self) {
 	/** @type {import("@companion-module/base").SomeCompanionConfigField[]} */
 	let configuration_fields_arr = [
 		{
@@ -25,11 +25,21 @@ export function getConfigFields() {
 			type: 'number',
 			id: 'refresh_interval',
 			required: true,
-			width: 3,
+			width: 6,
 			default: 5000,
 			min: 1,
 			max: 600000,
 			label: 'GPIO Pins state refresh interval [ms]',
+		},
+		{
+			type: 'number',
+			id: 'base',
+			required: true,
+			width: 6,
+			default: self.config.base,
+			label: 'GPIO Base Pin number Offset',
+			min: 0,
+			max: 10240,
 		},
 	]
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { InstanceBase, InstanceStatus, combineRgb, runEntrypoint } from '@companion-module/base'
 import { Gpio } from 'onoff'
+import * as fs from 'fs'
 import { getConfigFields } from './config.js'
 
 /**
@@ -60,11 +61,45 @@ class GpioInstance extends InstanceBase {
 	 */
 	all_active_pin_states = new Map()
 
+	constructor(internal) {
+		super(internal)
+		// get base offset
+		this.base = this.getBaseOffset()
+	}
+
+	getBaseOffset() {
+		const GpioFolder = '/sys/class/gpio'
+		const readFileLines = (path) => fs.readFileSync(path, { encoding: 'utf8' }).toString().split('\n')
+
+		let base = 0
+		let which
+		const files = fs.readdirSync(GpioFolder)
+		files.forEach((file) => {
+			if (file.match(/^gpiochip/)) {
+				const lines = readFileLines(`${GpioFolder}/${file}/label`)
+				if (lines[0].match(/^pinctrl/)) {
+					which = file
+				}
+			}
+		})
+
+		if (which) {
+			const lines = readFileLines(`${GpioFolder}/${which}/base`)
+			base = parseInt(lines[0])
+		}
+
+		return base
+	}
+
 	getConfigFields() {
-		return getConfigFields()
+		return getConfigFields(this)
 	}
 
 	async init(config) {
+		if (!config.base) {
+			config.base = this.getBaseOffset()
+		}
+
 		this.config = config
 
 		if (Gpio.accessible) {
@@ -128,7 +163,7 @@ class GpioInstance extends InstanceBase {
 					this.log('info', `Setting pin ${pinNumber} to LOW (0)`)
 					if (isNaN(pinNumber)) return
 
-					await this.#setPinToState(pinNumber, 'LOW')
+					await this.#setPinToState(pinNumber + this.config.base, 'LOW')
 				},
 			},
 			set_pin_high: {
@@ -147,7 +182,7 @@ class GpioInstance extends InstanceBase {
 					this.log('info', `Setting pin ${pinNumber} to HIGH (1)`)
 					if (isNaN(pinNumber)) return
 
-					await this.#setPinToState(pinNumber, 'HIGH')
+					await this.#setPinToState(pinNumber + this.config.base, 'HIGH')
 				},
 			},
 		})
@@ -353,7 +388,7 @@ class GpioInstance extends InstanceBase {
 					},
 				],
 				callback: (feedback) => {
-					const pinState = this.all_active_pin_states.get(Number(feedback.options.gpio_pin_number))
+					const pinState = this.all_active_pin_states.get(Number(feedback.options.gpio_pin_number + this.config.base))
 					if (pinState == 'HIGH') {
 						return { bgcolor: Number(feedback.options.bg_high) }
 					} else if (pinState == 'LOW') {
@@ -370,7 +405,7 @@ class GpioInstance extends InstanceBase {
 		this.log('info', 'Initialising variables')
 
 		/** @type {import('@companion-module/base').CompanionVariableDefinition[]} */
-		const variableDefinitions = []
+		const variableDefinitions = [{ name: 'Pin Base Offset', variableId: 'base' }]
 
 		for (const pinNumber of this.all_active_pin_nums) {
 			variableDefinitions.push({
@@ -380,6 +415,7 @@ class GpioInstance extends InstanceBase {
 		}
 
 		this.setVariableDefinitions(variableDefinitions)
+		this.setVariableValues( { base: this.config.base })
 	}
 
 	updateVariables() {
@@ -447,7 +483,7 @@ class GpioInstance extends InstanceBase {
 		for (const pinNumber of this.active_output_pins) {
 			console.log(`Pin_num: ${pinNumber} OUTPUT`)
 			try {
-				this.active_output_pin_objects.set(pinNumber, new Gpio(pinNumber, 'out'))
+				this.active_output_pin_objects.set(pinNumber, new Gpio(pinNumber + this.config.base, 'out'))
 			} catch (err) {
 				this.log('error', `GPIO Output pin ${pinNumber} is inaccessible`)
 				this.updateStatus(InstanceStatus.ConnectionFailure, `Pin ${pinNumber} is inaccessible\n` + err.toString())
@@ -468,7 +504,7 @@ class GpioInstance extends InstanceBase {
 			console.log(`Invert_values: ${invert_values}`)
 
 			try {
-				const gpioHandle = new Gpio(pinNumber, 'in', trigger_type, {
+				const gpioHandle = new Gpio(pinNumber + this.config.base, 'in', trigger_type, {
 					debounceTimeout: debounce_enable ? debounce_time : undefined,
 					activeLow: invert_values,
 				})
@@ -487,6 +523,7 @@ class GpioInstance extends InstanceBase {
 	 * @param {'HIGH' | 'LOW'} value
 	 */
 	async #setPinToState(pinNumber, value) {
+		pinNumber += this.config.base
 		const gpioHandle = this.active_output_pin_objects.get(pinNumber)
 		if (!gpioHandle) return
 
@@ -513,6 +550,7 @@ class GpioInstance extends InstanceBase {
 	 * @returns {PinState}
 	 */
 	poll_for_pin_state(pinNumber) {
+		pinNumber += this.config.base
 		const gpioHandle = this.active_output_pin_objects.get(pinNumber) ?? this.active_input_pin_objects.get(pinNumber)
 		if (!gpioHandle) return null
 
@@ -529,8 +567,8 @@ class GpioInstance extends InstanceBase {
 	}
 	poll_for_all_active_pin_states() {
 		for (const pinNumber of this.all_active_pin_states.keys()) {
-			const pinState = this.poll_for_pin_state(pinNumber)
-			this.all_active_pin_states.set(pinNumber, pinState)
+			const pinState = this.poll_for_pin_state(pinNumber + this.config.base)
+			this.all_active_pin_states.set(pinNumber + this.config.base, pinState)
 		}
 
 		this.checkFeedbacks('pin_state_feedback')
@@ -543,7 +581,7 @@ class GpioInstance extends InstanceBase {
 
 		console.log(this.active_input_pins_with_trigger)
 		for (const pinNumber of this.active_input_pins_with_trigger) {
-			const gpioHandle = this.active_input_pin_objects.get(pinNumber)
+			const gpioHandle = this.active_input_pin_objects.get(pinNumber + this.config.base)
 			if (!gpioHandle) continue
 
 			gpioHandle.watch((err, value) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -415,7 +415,7 @@ class GpioInstance extends InstanceBase {
 		}
 
 		this.setVariableDefinitions(variableDefinitions)
-		this.setVariableValues( { base: this.config.base })
+		this.setVariableValues({ base: this.config.base })
 	}
 
 	updateVariables() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raspberry-gpio",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "main": "lib/main.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Newer kernels shift the gpio pins to a number greater than zero.
This adds a pin number offset, extracted from the O/S configuration.
This offset is applied to each API pin request.
Should fix #20 